### PR TITLE
Add auto-merge Dependabot PRs workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,25 @@
+name: Auto-merge Dependabot PRs
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/auto-merge-dependabot.yml` workflow
- This workflow automatically approves and merges Dependabot PRs
- Source: [service-hmcts-crime-springboot-template](https://github.com/hmcts/service-hmcts-crime-springboot-template/blob/main/.github/workflows/auto-merge-dependabot.yml)

## Test plan
- [ ] Verify workflow file is correctly added
- [ ] Confirm workflow triggers on Dependabot PRs