### PR TITLE
Enrich API info.description with plain English marketplace summary

### DIFF
--- a/src/main/resources/openapi/openapi-spec.yml
+++ b/src/main/resources/openapi/openapi-spec.yml
@@ -9,7 +9,14 @@ servers:
 
 info:
   title: Common Platform API Scheduling and Listing Court Schedule
-  description: Scheduling and Listing API providing the court schedule
+  description: |
+    Returns the court hearing schedule for a given case, showing when and where
+    hearings are listed to take place.
+
+    For each hearing the response includes the court building, court room, sitting
+    times, type of hearing, and the judge assigned. Used by listing officers who
+    manage court diaries and by legal teams who need to see upcoming hearing dates
+    for a case.
   version: 0.0.0
   contact:
     email: no-reply@hmcts.com


### PR DESCRIPTION
## What changed
- Replaced the single-line `info.description` in `openapi-spec.yml` with a multi-paragraph plain English explanation of the court schedule data returned, what each hearing includes, and who uses the API

## Why it's needed
The AMP catalog front door surfaces `info.description` as the first thing a consumer sees when browsing the marketplace. The previous one-liner ("Scheduling and Listing API providing the court schedule") gave no useful context. The new description explains court house, room, sitting times, hearing type, and judiciary in business terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)