### PR TITLE
feat: set backend service_url explicitly per environment (AMP-913)

### DIFF
--- a/infrastructure/apis.tf
+++ b/infrastructure/apis.tf
@@ -3,10 +3,6 @@ locals {
     for api_key, api in var.apis :
     api_key => yamldecode(file(api.openapi_spec_path))
   }
-
-  apim_gw_host = "spnl-${var.env}-apim-int-gw"
-  apim_gw_fqdn = "${local.apim_gw_host}.${join(".", ["cpp", "nonlive"])}"
-  service_url  = "https://${local.apim_gw_fqdn}/amp/slc"
 }
 
 module "apis" {
@@ -44,7 +40,7 @@ module "apis" {
   )
 
   protocols             = each.value.protocols
-  service_url           = local.service_url
+  service_url           = var.service_url
   subscription_required = each.value.subscription_required
   api_type              = each.value.api_type
 

--- a/infrastructure/sbox.tfvars
+++ b/infrastructure/sbox.tfvars
@@ -1,5 +1,6 @@
 api_mgmt_rg   = "rg-sps-platform-sbox"
 api_mgmt_name = "sps-api-mgmt-sbox"
+service_url   = "https://devamp01.ingress01.dev.nl.cjscp.org.uk"
 
 apim_product = {
   name                          = "cp-crime-schedulingandlisting"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -67,6 +67,11 @@ variable "apim_product" {
   })
 }
 
+variable "service_url" {
+  type        = string
+  description = "Backend service base URL. Set per environment in tfvars."
+}
+
 variable "apis" {
   description = "Map of APIs to register in APIM. Details are sourced from the referenced OpenAPI spec file."
   type = map(object({


### PR DESCRIPTION
## Summary

- Replaces the derived internal gateway URL with an explicit `service_url` variable set per environment in tfvars
- Sbox and dev both point to the dev backend (`devamp01.ingress01.dev.nl.cjscp.org.uk`) — no sbox backend exists yet
- Prod tfvars will set `prdamp01.ingress01.prd.lv.cjscp.org.uk` when added

## Test plan

- [ ] Secrets scanner passes
- [ ] Terraform plan shows updated service URL on the API resource