### PR TITLE
feat: set backend service_url from service_host variable (AMP-913)

### DIFF
--- a/infrastructure/apis.tf
+++ b/infrastructure/apis.tf
@@ -4,9 +4,7 @@ locals {
     api_key => yamldecode(file(api.openapi_spec_path))
   }
 
-  apim_gw_host = "spnl-${var.env}-apim-int-gw"
-  apim_gw_fqdn = "${local.apim_gw_host}.${join(".", ["cpp", "nonlive"])}"
-  service_url  = "https://${local.apim_gw_fqdn}/amp/slc"
+  service_url = "https://${var.service_host}"
 }
 
 module "apis" {

--- a/infrastructure/sbox.tfvars
+++ b/infrastructure/sbox.tfvars
@@ -1,5 +1,6 @@
 api_mgmt_rg   = "rg-sps-platform-sbox"
 api_mgmt_name = "sps-api-mgmt-sbox"
+service_host  = "devamp01.ingress01.dev.nl.cjscp.org.uk"
 
 apim_product = {
   name                          = "cp-crime-schedulingandlisting"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -67,6 +67,11 @@ variable "apim_product" {
   })
 }
 
+variable "service_host" {
+  type        = string
+  description = "Backend service hostname (without scheme). https:// is prepended in apis.tf."
+}
+
 variable "apis" {
   description = "Map of APIs to register in APIM. Details are sourced from the referenced OpenAPI spec file."
   type = map(object({


### PR DESCRIPTION
## Summary

- Replaces the old hardcoded APIM gateway URL with an explicit `service_host` variable set per environment in tfvars
- `https://` is prepended in `apis.tf` so the tfvars value is a plain hostname with no URL scheme
- Sbox points to dev backend (`devamp01.ingress01.dev.nl.cjscp.org.uk`) as no sbox backend exists

## Test plan

- [ ] Secrets scanner passes (hostname without `https://` in tfvars)
- [ ] Terraform plan shows correct backend URL on the API resource