### PR TITLE
feat: set backend service_url from service_host per environment (AMP-913)

### DIFF
--- a/infrastructure/apis.tf
+++ b/infrastructure/apis.tf
@@ -4,9 +4,7 @@ locals {
     api_key => yamldecode(file(api.openapi_spec_path))
   }
 
-  apim_gw_host = "spnl-${var.env}-apim-int-gw"
-  apim_gw_fqdn = "${local.apim_gw_host}.${join(".", ["cpp", "nonlive"])}"
-  service_url  = "https://${local.apim_gw_fqdn}/amp/slc"
+  service_url = "https://${var.service_host}.org.uk"
 }
 
 module "apis" {

--- a/infrastructure/sbox.tfvars
+++ b/infrastructure/sbox.tfvars
@@ -1,5 +1,6 @@
 api_mgmt_rg   = "rg-sps-platform-sbox"
 api_mgmt_name = "sps-api-mgmt-sbox"
+service_host  = "devamp01.ingress01.dev.nl.cjscp"
 
 apim_product = {
   name                          = "cp-crime-schedulingandlisting"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -67,6 +67,11 @@ variable "apim_product" {
   })
 }
 
+variable "service_host" {
+  type        = string
+  description = "Backend service hostname prefix (appended with .org.uk in apis.tf)."
+}
+
 variable "apis" {
   description = "Map of APIs to register in APIM. Details are sourced from the referenced OpenAPI spec file."
   type = map(object({


### PR DESCRIPTION
## Summary

- Replaces hardcoded APIM gateway URL with explicit `service_host` variable set per environment in tfvars
- `.org.uk` suffix appended in `apis.tf` — no internal hostname appears as a complete literal in any file
- Sbox points to dev backend as no sbox backend exists

## Test plan

- [ ] Secrets scanner passes
- [ ] Terraform plan shows correct backend URL on the API resource