### PR TITLE
feat: add guests group to sbox product access control (AMP-913)

### DIFF
--- a/infrastructure/sbox.tfvars
+++ b/infrastructure/sbox.tfvars
@@ -8,7 +8,7 @@ apim_product = {
   subscriptions_limit           = 20
   approval_required             = false
   published                     = true
-  product_access_control_groups = ["developers", "administrators"]
+  product_access_control_groups = ["developers", "administrators", "guests"]
   product_policy                = ""
 }
 


### PR DESCRIPTION
## Summary

- Adds `guests` to `product_access_control_groups` in sbox so anonymous portal visitors can see the API listing without signing in
- APIs remain subscription-protected — guests can browse but still need a subscription key to call them
- Depends on #130 (merge first)

## Test plan

- [ ] Anonymous user can see the court schedule API in the portal APIs page
- [ ] API still requires subscription key to call