### PR TITLE
feat: add APIM product policy with Entra JWT auth and rate limiting (AMP-913)

### DIFF
--- a/infrastructure/apis.tf
+++ b/infrastructure/apis.tf
@@ -40,7 +40,7 @@ module "apis" {
   )
 
   protocols             = each.value.protocols
-  service_url           = "https://${each.value.service_host}.org.uk"
+  service_url           = "https://${each.value.service_host}.org.uk${each.value.service_path}"
   subscription_required = each.value.subscription_required
   api_type              = each.value.api_type
 

--- a/infrastructure/apis.tf
+++ b/infrastructure/apis.tf
@@ -3,8 +3,6 @@ locals {
     for api_key, api in var.apis :
     api_key => yamldecode(file(api.openapi_spec_path))
   }
-
-  service_url = "https://${var.service_host}.org.uk"
 }
 
 module "apis" {
@@ -42,7 +40,7 @@ module "apis" {
   )
 
   protocols             = each.value.protocols
-  service_url           = local.service_url
+  service_url           = "https://${each.value.service_host}.org.uk"
   subscription_required = each.value.subscription_required
   api_type              = each.value.api_type
 

--- a/infrastructure/policies/product-policy.xml
+++ b/infrastructure/policies/product-policy.xml
@@ -1,0 +1,48 @@
+<policies>
+    <inbound>
+        <choose>
+            <when condition="@(context.Request.Headers.ContainsKey(&quot;Authorization&quot;))">
+                <validate-jwt header-name="Authorization" failed-validation-httpcode="401" failed-validation-error-message="Your JWT token failed CNP validation! ">
+                    <openid-config url="https://login.microsoftonline.com/${tenant_id}/v2.0/.well-known/openid-configuration" />
+                    <audiences>
+                        <audience>${client_id}</audience>
+                    </audiences>
+                    <issuers>
+                        <issuer>https://login.microsoftonline.com/${tenant_id}/v2.0</issuer>
+                    </issuers>
+                    <required-claims>
+                        <claim name="aud" match="any">
+                            <value>${client_id}</value>
+                        </claim>
+                        <claim name="roles" match="any">
+                            <value>app.read</value>
+                        </claim>
+                    </required-claims>
+                </validate-jwt>
+            </when>
+            <otherwise>
+                <return-response>
+                    <set-status code="401" reason="Unauthorized" />
+                    <set-header name="Content-Type" exists-action="override">
+                        <value>application/json</value>
+                    </set-header>
+                    <set-body>{"error":"Missing Authorization header."}</set-body>
+                </return-response>
+            </otherwise>
+        </choose>
+        <rate-limit-by-key calls="30" renewal-period="60" counter-key="@((context.Subscription?.Key ?? context.Request.IpAddress) + &quot;:slc&quot;)" />
+        <quota-by-key calls="500" renewal-period="86400" counter-key="@((context.Subscription?.Key ?? context.Request.IpAddress) + &quot;:slc&quot;)" />
+        <base />
+    </inbound>
+    <backend>
+        <limit-concurrency key="@((context.Subscription?.Key ?? context.Request.IpAddress) + &quot;:slc&quot;)" max-count="10">
+            <forward-request />
+        </limit-concurrency>
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/infrastructure/products.tf
+++ b/infrastructure/products.tf
@@ -9,5 +9,8 @@ module "product" {
   approval_required             = var.apim_product.approval_required
   published                     = var.apim_product.published
   product_access_control_groups = var.apim_product.product_access_control_groups
-  product_policy                = var.apim_product.product_policy
+  product_policy = templatefile("${path.module}/policies/product-policy.xml", {
+    tenant_id = var.entra_tenant_id
+    client_id = var.entra_client_id
+  })
 }

--- a/infrastructure/sbox.tfvars
+++ b/infrastructure/sbox.tfvars
@@ -1,6 +1,5 @@
 api_mgmt_rg   = "rg-sps-platform-sbox"
 api_mgmt_name = "sps-api-mgmt-sbox"
-service_host  = "devamp01.ingress01.dev.nl.cjscp"
 
 apim_product = {
   name                          = "cp-crime-schedulingandlisting"
@@ -9,12 +8,15 @@ apim_product = {
   approval_required             = false
   published                     = true
   product_access_control_groups = ["developers", "administrators", "guests"]
-  product_policy                = ""
 }
+
+entra_tenant_id = "e2995d11-9947-4e78-9de6-d44e0603518e"
+entra_client_id = "b69a4519-354b-481b-88a5-65ab7c83273e"
 
 apis = {
   courtschedule = {
     openapi_spec_path = "../src/main/resources/openapi/openapi-spec.yml"
+    service_host      = "devamp01.ingress01.dev.nl.cjscp"
     revision          = "1"
   }
 }

--- a/infrastructure/sbox.tfvars
+++ b/infrastructure/sbox.tfvars
@@ -16,7 +16,8 @@ entra_client_id = "b69a4519-354b-481b-88a5-65ab7c83273e"
 apis = {
   courtschedule = {
     openapi_spec_path = "../src/main/resources/openapi/openapi-spec.yml"
-    service_host      = "devamp01.ingress01.dev.nl.cjscp"
+    service_host      = "spnl-dev-apim-int-gw.dev.nl.cjscp"
+    service_path      = "/amp/slc"
     revision          = "1"
   }
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -63,19 +63,24 @@ variable "apim_product" {
     approval_required             = optional(bool, true)
     published                     = optional(bool, true)
     product_access_control_groups = optional(list(string), [])
-    product_policy                = optional(string, "")
   })
 }
 
-variable "service_host" {
+variable "entra_tenant_id" {
   type        = string
-  description = "Backend service hostname prefix (appended with .org.uk in apis.tf)."
+  description = "Entra tenant ID used in the product JWT validation policy."
+}
+
+variable "entra_client_id" {
+  type        = string
+  description = "Entra client ID (audience) used in the product JWT validation policy."
 }
 
 variable "apis" {
   description = "Map of APIs to register in APIM. Details are sourced from the referenced OpenAPI spec file."
   type = map(object({
     openapi_spec_path     = string
+    service_host          = string
     name                  = optional(string)
     display_name          = optional(string)
     path                  = optional(string)

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -81,6 +81,7 @@ variable "apis" {
   type = map(object({
     openapi_spec_path     = string
     service_host          = string
+    service_path          = optional(string, "")
     name                  = optional(string)
     display_name          = optional(string)
     path                  = optional(string)


### PR DESCRIPTION
## Summary

- Adds APIM product-level policy with Entra JWT validation (always-on, no feature toggle) and rate limiting ported from CP APIM
- Policy template (`infrastructure/policies/product-policy.xml`) uses `templatefile()` so Entra tenant/client IDs are injected per environment — nonlive and live use different tenant IDs
- Aligns `service_host` to a per-API field in the `apis` map (following the `amp-api-example` pattern) rather than a global variable, making multi-environment config explicit
- Adds `guests` group to sbox product access control

## Policy applied at product level

- JWT validation against Entra — 401 if `Authorization` header missing or token invalid
- Rate limit: 30 calls/min per subscription key
- Quota: 500 calls/day per subscription key
- Concurrency: max 10 in-flight requests per subscription key

## Test plan

- [ ] Terraform plan runs clean on PR
- [ ] Verify policy applies in `sps-api-mgmt-sbox` after merge
- [ ] Test with valid Entra token — expect 200
- [ ] Test without `Authorization` header — expect 401 `Missing Authorization header.`
- [ ] Test with invalid token — expect 401 `Your JWT token failed validation`