### PR TITLE
feat: move APIM policy from product to API level (AMP-913)

### DIFF
--- a/infrastructure/apis.tf
+++ b/infrastructure/apis.tf
@@ -47,3 +47,18 @@ module "apis" {
   swagger_url    = file(each.value.openapi_spec_path)
   content_format = "openapi"
 }
+
+resource "azurerm_api_management_api_policy" "api_policy" {
+  for_each = var.apis
+
+  api_name            = module.apis[each.key].name
+  api_management_name = var.api_mgmt_name
+  resource_group_name = var.api_mgmt_rg
+
+  xml_content = templatefile("${path.module}/policies/api-policy.xml", {
+    tenant_id = var.entra_tenant_id
+    client_id = var.entra_client_id
+  })
+
+  depends_on = [module.apis]
+}

--- a/infrastructure/policies/api-policy.xml
+++ b/infrastructure/policies/api-policy.xml
@@ -26,7 +26,7 @@
                     <set-header name="Content-Type" exists-action="override">
                         <value>application/json</value>
                     </set-header>
-                    <set-body>{"error":"Missing Authorization header."}</set-body>
+                    <set-body>{"error":"Missing CNP Authorization header."}</set-body>
                 </return-response>
             </otherwise>
         </choose>

--- a/infrastructure/products.tf
+++ b/infrastructure/products.tf
@@ -9,8 +9,5 @@ module "product" {
   approval_required             = var.apim_product.approval_required
   published                     = var.apim_product.published
   product_access_control_groups = var.apim_product.product_access_control_groups
-  product_policy = templatefile("${path.module}/policies/product-policy.xml", {
-    tenant_id = var.entra_tenant_id
-    client_id = var.entra_client_id
-  })
+  product_policy                = ""
 }


### PR DESCRIPTION
## Summary

- Moves JWT auth, rate limiting and quota policy from product level to API level
- Policy is now visible directly on the API in the APIM portal Design tab — no need to look at the product to understand what's protecting the API
- Renames `product-policy.xml` → `api-policy.xml`
- Product policy cleared to `""` — Terraform will destroy `azurerm_api_management_product_policy`
- New `azurerm_api_management_api_policy` resource iterates over all APIs in the map, keeping future APIs automatically covered

## Why API level over product level

Policy at product level is less discoverable — you have to know to look at the product. API level makes the policy visible in the same place as the API definition, matching the CP pattern and making it easier to reason about what auth is applied.

## Test plan

- [ ] Terraform plan shows: destroy product policy, create API policy
- [ ] No `Authorization` header → `401 Missing CNP Authorization header.`
- [ ] Invalid token → `401 Your JWT token failed CNP validation!`
- [ ] Valid token → passes through to backend