### PR TITLE
Update sbox Entra tenant ID

### DIFF
--- a/infrastructure/sbox.tfvars
+++ b/infrastructure/sbox.tfvars
@@ -10,7 +10,7 @@ apim_product = {
   product_access_control_groups = ["developers", "administrators", "guests"]
 }
 
-entra_tenant_id = "e2995d11-9947-4e78-9de6-d44e0603518e"
+entra_tenant_id = "d44f885c-4fac-47bf-afde-d7d861ec4d7b"
 entra_client_id = "b69a4519-354b-481b-88a5-65ab7c83273e"
 
 apis = {


### PR DESCRIPTION
## Summary
- `infrastructure/sbox.tfvars` — update `entra_tenant_id` for the sandbox APIM product to the new Entra tenant:
  - `entra_tenant_id`: `e2995d11-9947-4e78-9de6-d44e0603518e` → `d44f885c-4fac-47bf-afde-d7d861ec4d7b`
- `entra_client_id` is unchanged.

(Supersedes #143, which incorrectly also changed `entra_client_id`.)

## Test plan
- [ ] Confirm the sandbox Terraform plan/apply picks up the new tenant ID without other unintended changes.