### PR TITLE
Update sbox Entra client ID

### DIFF
--- a/infrastructure/sbox.tfvars
+++ b/infrastructure/sbox.tfvars
@@ -11,7 +11,7 @@ apim_product = {
 }
 
 entra_tenant_id = "d44f885c-4fac-47bf-afde-d7d861ec4d7b"
-entra_client_id = "b69a4519-354b-481b-88a5-65ab7c83273e"
+entra_client_id = "30288840-e345-4543-99ee-f9253d789339"
 
 apis = {
   courtschedule = {


### PR DESCRIPTION
## Summary
- `infrastructure/sbox.tfvars` — update `entra_client_id` for the sandbox APIM product to the new Entra app registration:
  - `entra_client_id`: `b69a4519-354b-481b-88a5-65ab7c83273e` → `30288840-e345-4543-99ee-f9253d789339`
- `entra_tenant_id` is unchanged (already `d44f885c-4fac-47bf-afde-d7d861ec4d7b` from #144).

## Test plan
- [ ] Confirm the sandbox Terraform plan/apply picks up the new client ID without other unintended changes.