### PR TITLE
Add CORS policy for API Marketplace browser calls

### DIFF
--- a/infrastructure/policies/api-policy.xml
+++ b/infrastructure/policies/api-policy.xml
@@ -1,5 +1,18 @@
 <policies>
     <inbound>
+        <cors allow-credentials="false">
+            <allowed-origins>
+                <origin>https://hmcts.github.io</origin>
+            </allowed-origins>
+            <allowed-methods>
+                <method>GET</method>
+            </allowed-methods>
+            <allowed-headers>
+                <header>Authorization</header>
+                <header>Ocp-Apim-Subscription-Key</header>
+                <header>Content-Type</header>
+            </allowed-headers>
+        </cors>
         <choose>
             <when condition="@(context.Request.Headers.ContainsKey(&quot;Authorization&quot;))">
                 <validate-jwt header-name="Authorization" failed-validation-httpcode="401" failed-validation-error-message="Your JWT token failed CNP validation! ">


### PR DESCRIPTION
## Summary
- Add a `<cors>` policy to `infrastructure/policies/api-policy.xml`, allowing `https://hmcts.github.io` to call this API directly from the browser (`GET`, with `Authorization`/`Ocp-Apim-Subscription-Key`/`Content-Type` headers).
- Needed so the API Marketplace's application detail page can offer a live "Test connection" feature (client-credentials token + API call) rather than only static code samples.
- Without this, the browser's CORS preflight is rejected (confirmed via `curl -X OPTIONS` — got a plain 404 with no `Access-Control-Allow-*` headers) before the request ever reaches JWT validation.

## Test plan
- [ ] `curl -X OPTIONS` with `Origin: https://hmcts.github.io` returns `Access-Control-Allow-Origin: https://hmcts.github.io` and the expected allowed methods/headers.
- [ ] A browser `fetch()` from `https://hmcts.github.io/hmcts-api-marketplace/` to this API succeeds (no CORS error in console) when a valid token + subscription key are supplied.
- [ ] Confirm no other origins can call the API (CORS only allows the one listed origin).